### PR TITLE
Event listener is only fired once when uploading custom data multiple…

### DIFF
--- a/Nebula-UIs/InitializeSession.js
+++ b/Nebula-UIs/InitializeSession.js
@@ -165,7 +165,7 @@ function sessionChange() {
             "Upload Data": function () {
                 piheight = 0;
                 document.getElementById("fileInput")
-                    .addEventListener("change", fileSelectWrapper(dropdownOptions), false);
+                    .addEventListener("change", fileSelectWrapper(dropdownOptions), { once: true });
                 $('#fileInput').click();
                 $(this).dialog("close");
             },


### PR DESCRIPTION
… times

## Describe your changes
When attempting to upload custom data multiple times, the event listener was registered more than once causing the callback function to be invoked multiple times. The `once` option was added to `addEventListener` to prevent this.

## Issue ticket number and link
https://github.com/ironsj/nebula/issues/70

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have added through tests
- [X] My code builds clean with no warnings or errors

![Pull request image](https://i.imgflip.com/42crbn.jpg)
